### PR TITLE
Cookiecutter #2

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -66,7 +66,7 @@ jobs:
           # Since ./site only contains HTML files (generated from markdown by MkDocs),
           # no markdown files will be deployed. The markdown files exist only during
           # the build process and are never committed to any branch.
-          personal_token: ${{ secrets.GHPAGES_DEPLOY_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
           publish_branch: gh-pages
           allow_empty_commit: false


### PR DESCRIPTION
- Replaces the use of GHPAGES_DEPLOY_KEY with GITHUB_TOKEN for GitHub Pages deployment in the docs workflow.
- Aligns with GitHub Actions best practices for authentication.